### PR TITLE
Remove Amazon retailer integration

### DIFF
--- a/PRICE_COMPARISON.md
+++ b/PRICE_COMPARISON.md
@@ -10,10 +10,10 @@ The price comparison system currently supports the following retailers:
 
 - **JB Hi-Fi** - Electronics and entertainment
 - **Harvey Norman** - Electronics and appliances  
-- **Amazon AU** - Wide range of products
+- **The Good Guys** - Appliances and electronics
 - **Officeworks** - Office supplies and electronics
 
-*Note: Big W and Kmart were removed due to prevalence of marketplace sellers affecting price accuracy.*
+*Note: Amazon AU, Big W and Kmart were removed due to marketplace seller listings affecting price accuracy and reliability.*
 
 ## How It Works
 
@@ -241,7 +241,7 @@ Found price comparisons for iPad Mini A17 Pro 8.3" WiFi 128GB Space Grey
 
 🏪 Officeworks: $899.00
 🔗 JB Hi-Fi: $849.00 📉 Save $50.00! ✅ Price match eligible!
-🔗 Amazon AU: $869.00 📉 Save $30.00! ✅ Price match eligible!
+🔗 The Good Guys: $869.00 📉 Save $30.00! ✅ Price match eligible!
 
 🎯 Price Match Opportunity
 Show JB Hi-Fi price ($849.00) to Officeworks for a potential price match!
@@ -259,8 +259,7 @@ Found prices for Sony WH-1000XM4 across retailers
 
 🔗 JB Hi-Fi: $348.00
 🔗 Harvey Norman: $399.00
-🔗 Amazon AU: $329.00
-🔗 Big W: $369.00
+🔗 The Good Guys: $329.00
 ```
 
 ## Troubleshooting

--- a/SETUP_FIRECRAWL.md
+++ b/SETUP_FIRECRAWL.md
@@ -5,7 +5,7 @@ The price comparison feature is now integrated into your Officeworks Stock Check
 ## Current Status
 
 ✅ **Implemented Features:**
-- Price comparison system with 6 major retailers (JB Hi-Fi, Harvey Norman, Amazon AU, Big W, Kmart, Officeworks)
+- Price comparison system with 4 major retailers (JB Hi-Fi, Harvey Norman, The Good Guys, Officeworks)
 - Enhanced `/check` command with `compare_prices` parameter
 - New standalone `/compare` command for any product search
 - Intelligent product matching and price analysis
@@ -75,7 +75,7 @@ After configuring Firecrawl, test the functionality:
 
 With Firecrawl properly configured, you should see:
 
-1. **Real Price Data**: Actual prices from JB Hi-Fi, Harvey Norman, Amazon AU, etc.
+1. **Real Price Data**: Actual prices from JB Hi-Fi, Harvey Norman, The Good Guys, etc.
 2. **Price Match Opportunities**: Clear indicators when competitors have lower prices
 3. **Detailed Product Information**: Better product matching and descriptions
 4. **Up-to-date Pricing**: Current prices from retailer websites

--- a/bot.py
+++ b/bot.py
@@ -621,7 +621,7 @@ class CheckCompetitorsButton(discord.ui.Button):
             try:
                 # Perform price comparison
                 comparisons = await price_comparison.search_all_retailers(
-                    self.product_name, self.officeworks_price, max_retailers=4
+                    self.product_name, self.officeworks_price, max_retailers=3
                 )
                 
                 if comparisons:

--- a/price_comparison.py
+++ b/price_comparison.py
@@ -93,36 +93,6 @@ class PriceComparison:
                 ],
                 price_match_threshold=0.3
             ),
-            'amazon': RetailerConfig(
-                name="Amazon AU",
-                base_url="https://www.amazon.com.au",
-                search_url="https://www.amazon.com.au/s?k={query}&ref=nb_sb_noss",
-                price_selectors=[
-                    '.a-price-whole',
-                    '.a-price .a-offscreen',
-                    '.a-price-symbol + .a-price-whole',
-                    '.price .a-price-whole',
-                    '.a-price-amount .a-offscreen',
-                    '.sx-price .a-offscreen',
-                    '.a-row .a-price .a-offscreen'
-                ],
-                title_selectors=[
-                    '[data-cy="title-recipe"]',
-                    '.a-size-medium.a-color-base',
-                    '.s-size-mini .a-color-base',
-                    'h2 .a-link-normal .a-text-normal',
-                    '.s-link-style .a-text-normal',
-                    'h3.s-size-mini span',
-                    '.a-text-normal.a-color-base.a-size-base-plus'
-                ],
-                link_selectors=[
-                    '[data-cy="title-recipe"] a',
-                    '.s-product-image-container a',
-                    '.a-link-normal',
-                    '.s-link-style'
-                ],
-                price_match_threshold=0.3
-            ),
             'good_guys': RetailerConfig(
                 name="The Good Guys",
                 base_url="https://www.thegoodguys.com.au",
@@ -177,8 +147,8 @@ class PriceComparison:
             )
         }
     
-    async def search_all_retailers(self, product_name: str, officeworks_price: float, 
-                                 max_retailers: int = 4) -> List[Dict]:
+    async def search_all_retailers(self, product_name: str, officeworks_price: float,
+                                 max_retailers: int = 3) -> List[Dict]:
         """Search all configured retailers for price comparisons"""
         if not self.firecrawl_client:
             return []
@@ -341,14 +311,8 @@ class PriceComparison:
             }
             
             # Create a specific prompt for this retailer and query
-            if retailer.name == "Amazon AU":
-                prompt = f"""Extract product information from this Amazon Australia search results page for "{query}". 
-                Focus on genuine Apple products or exact product matches, ignore cases, accessories, and third-party items unless specifically relevant.
-                Look for products with prices in AUD ($). Extract the product name, price (as a number without currency symbols), product URL, availability status, brand, and model.
-                Ignore "Renewed" products unless specifically searching for them.
-                Return up to 8 most relevant products."""
-            elif retailer.name == "Harvey Norman":
-                prompt = f"""Extract product information from this Harvey Norman search results page for "{query}". 
+            if retailer.name == "Harvey Norman":
+                prompt = f"""Extract product information from this Harvey Norman search results page for "{query}".
                 Focus on main product listings, ignore accessories unless specifically relevant.
                 Look for products with clear pricing. Extract the product name, price (as a number without currency symbols), product URL, availability status, brand, and model.
                 Return up to 10 most relevant products."""
@@ -875,7 +839,7 @@ class PriceComparison:
         # Common tech brands
         brands = [
             'tp-link', 'tplink', 'apple', 'samsung', 'sony', 'lg', 'hp', 'dell', 'lenovo',
-            'asus', 'acer', 'microsoft', 'google', 'amazon', 'netgear', 'linksys',
+            'asus', 'acer', 'microsoft', 'google', 'netgear', 'linksys',
             'cisco', 'nvidia', 'intel', 'amd', 'logitech', 'razer', 'corsair', 'belkin'
         ]
         

--- a/test_updated_retailers.py
+++ b/test_updated_retailers.py
@@ -22,8 +22,8 @@ async def test_updated_retailers():
     print("\n1. Testing updated retailer list...")
     retailers = price_comparison.retailers
     
-    expected_retailers = ['jb_hifi', 'harvey_norman', 'amazon', 'officeworks']
-    removed_retailers = ['bigw', 'kmart']
+    expected_retailers = ['jb_hifi', 'harvey_norman', 'good_guys', 'officeworks']
+    removed_retailers = ['amazon', 'bigw', 'kmart']
     
     print(f"   Configured retailers: {list(retailers.keys())}")
     
@@ -51,12 +51,12 @@ async def test_updated_retailers():
     print(f"   Expected format: {expected_hn}")
     print(f"   ✓ Matches catalogsearch format: {'/catalogsearch/result/?q=' in hn_url}")
     
-    # Amazon - should use /s?k= format
-    amz_url = retailers['amazon'].search_url.format(query=test_query.replace(' ', '+'))
-    expected_amz = "https://www.amazon.com.au/s?k=ipad+mini+a17&ref=nb_sb_noss"
-    print(f"   Amazon URL: {amz_url}")
-    print(f"   Expected format: {expected_amz}")
-    print(f"   ✓ Matches /s?k= format: {'/s?k=' in amz_url}")
+    # The Good Guys - should use standard search format
+    gg_url = retailers['good_guys'].search_url.format(query=test_query.replace(' ', '+'))
+    expected_gg = "https://www.thegoodguys.com.au/search?q=ipad+mini+a17"
+    print(f"   The Good Guys URL: {gg_url}")
+    print(f"   Expected format: {expected_gg}")
+    print(f"   ✓ Matches search format: {'/search?q=' in gg_url}")
     
     # Test 3: Check enhanced selectors
     print("\n3. Testing enhanced selectors...")
@@ -67,24 +67,24 @@ async def test_updated_retailers():
     print(f"   - Includes special-price: {'.special-price .price' in hn_selectors.price_selectors}")
     print(f"   - Includes regular-price: {'.regular-price .price' in hn_selectors.price_selectors}")
     
-    # Amazon selectors  
-    amz_selectors = retailers['amazon']
-    print(f"   Amazon price selectors: {len(amz_selectors.price_selectors)}")
-    print(f"   - Includes a-price-amount: {'.a-price-amount .a-offscreen' in amz_selectors.price_selectors}")
-    print(f"   - Includes sx-price: {'.sx-price .a-offscreen' in amz_selectors.price_selectors}")
+    # The Good Guys selectors
+    gg_selectors = retailers['good_guys']
+    print(f"   The Good Guys price selectors: {len(gg_selectors.price_selectors)}")
+    print(f"   - Includes .price: {'.price' in gg_selectors.price_selectors}")
+    print(f"   - Includes .ProductPrice span: {'.ProductPrice span' in gg_selectors.price_selectors}")
     
     # Test 4: Test extraction prompts
     print("\n4. Testing retailer-specific prompts...")
     
     # Test _extract_with_firecrawl method (simulated)
     test_url = "https://example.com"
-    test_retailer_amazon = retailers['amazon']
     test_retailer_hn = retailers['harvey_norman']
     test_retailer_jb = retailers['jb_hifi']
-    
+    test_retailer_gg = retailers['good_guys']
+
     print("   Prompt differences by retailer:")
-    print(f"   - Amazon: Focuses on genuine Apple products, ignores Renewed")
     print(f"   - Harvey Norman: Focuses on main listings, ignores accessories")
+    print(f"   - The Good Guys: Focuses on Apple products and electronics")
     print(f"   - JB Hi-Fi: Standard product extraction")
     
     # Test 5: Check max retailers setting
@@ -102,23 +102,23 @@ async def test_updated_retailers():
     
     print("\n📋 Summary of Changes:")
     print("✓ Harvey Norman: Updated to use catalogsearch URL format")
-    print("✓ Amazon AU: Updated to use /s?k= URL format with ref parameter")
+    print("✓ The Good Guys: Confirmed search configuration and selectors")
     print("✓ Big W: Removed due to marketplace sellers")
     print("✓ Kmart: Removed due to marketplace sellers")
     print("✓ Enhanced selectors for better price extraction")
     print("✓ Retailer-specific extraction prompts")
-    print("✓ Reduced max_retailers to 3 (JB Hi-Fi, Harvey Norman, Amazon)")
+    print("✓ Reduced max_retailers to 3 (JB Hi-Fi, Harvey Norman, The Good Guys)")
     
     print("\n🎯 Expected Improvements:")
     print("• Better Harvey Norman product extraction")
-    print("• More accurate Amazon AU price matching")
+    print("• Consistent The Good Guys pricing results")
     print("• Reduced noise from marketplace sellers")
     print("• Faster searches with fewer retailers")
     print("• Higher quality price comparison results")
     
     print("\n🔗 URL Formats:")
     print("• Harvey Norman: /catalogsearch/result/?q={query}")
-    print("• Amazon AU: /s?k={query}&ref=nb_sb_noss")
+    print("• The Good Guys: /search?q={query}")
     print("• JB Hi-Fi: /search?query={query} (unchanged)")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the Amazon AU retailer configuration from the price comparison service and tighten the default retailer search limit
- adjust bot interactions and retailer configuration test outputs to reflect the remaining retailers, highlighting The Good Guys instead of Amazon
- refresh documentation to describe the updated retailer list and example comparison results without Amazon

## Testing
- pytest *(fails: DISCORD_BOT_TOKEN environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68d081524fd48332b9713be6705745b6